### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Rhythm [![Build Status](https://api.travis-ci.com/apache/fineract-cn-rhythm.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-rhythm)  [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-rhythm)](https://hub.docker.com/r/apache/fineract-cn-rhythm/builds)
+# Apache Fineract CN Rhythm [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-rhythm)](https://hub.docker.com/r/apache/fineract-cn-rhythm/builds)
 
 This project provides a heart beatPublish for other services which need to start jobs to be executed once and only once at a defined time.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-rhythm).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.